### PR TITLE
bugfix: fix wrong tab navigation keymap

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -4,5 +4,5 @@
 local map = LazyVim.safe_keymap_set
 
 -- TAB NAVIGATION
-map("n", "gt", "<cmd>bprevious<cr>", { desc = "Go to previous tab page" })
-map("n", "gT", "<cmd>bnext<cr>", { desc = "Go to next tab page" })
+map("n", "gT", "<cmd>bprevious<cr>", { desc = "Go to previous tab page" })
+map("n", "gt", "<cmd>bnext<cr>", { desc = "Go to next tab page" })


### PR DESCRIPTION
### Bug

- We use `gT` to go to the next tab page
- We use `gt` to go to the previous tab page

### Fix

- We use `gt` to go to the next tab page
- We use `gT` to go to the previous tab page